### PR TITLE
fix!: useUser

### DIFF
--- a/src/features/profile/hooks/use-user.js
+++ b/src/features/profile/hooks/use-user.js
@@ -33,9 +33,9 @@ export default function useUser(id) {
 	useEffect(() => {
 		setState((state) => ({ ...state, loading: true }));
 
-		if (!userID) return;
-
 		let cancelled = false;
+
+		if (!userID) return;
 
 		async function getUserAndAttributes() {
 			const user = await getUserByID(userID);


### PR DESCRIPTION
This now sends a state.

Initially:
```js
state: { loading: true }
```
**And it always stays as `loading: true`**

UNTIL when ID is provided
```js
state: { loading: true }
```
and eventually
```js
state: { loading: false, data: {/*...*/} }
```
or if there's an error
```js
state: { loading: false, error: {/*...*/}, data: null }