### PR TITLE
fix!: localStorage null and renamed to data

### DIFF
--- a/src/hooks/use-local-storage.js
+++ b/src/hooks/use-local-storage.js
@@ -6,7 +6,7 @@ const useLocalStorage = (key) => {
 	useEffect(() => {
 		try {
 			const item = window.localStorage.getItem(key);
-			setData(item ? JSON.parse(item) : null);
+			setData(item ? JSON.parse(item) : {});
 		} catch (err) {
 			console.error(err);
 		}


### PR DESCRIPTION
This is a breaking change. You must now use useLocalStorage().data instead of .store().

Initial value will always be `null` until loaded from localstorage.

If loaded but hasn't found anything, it will be set to `{}`.