### PR TITLE
fix(InputField): input value can now be undefined

### DIFF
--- a/src/components/input-field/index.jsx
+++ b/src/components/input-field/index.jsx
@@ -22,7 +22,7 @@ const InputField = ({ icon = null, isError = false, value, handleChange, classNa
 				{icon && <span className="globalInputIcon">{icon}</span>}
 				<input
 					className={`globalInputContent globalInputField ${classes} ${className}`}
-					value={value || ""}
+					value={value}
 					onChange={handleChange}
 					{...restProps}
 				/>


### PR DESCRIPTION
Splash page uses `defaultValue` and having `value` be set to an empty string overwrites `defaultValue` which lead to display issues and errors in console about having to set `onChange`, so I'm reverting a change from #91.